### PR TITLE
fix: make discovered files order consistent

### DIFF
--- a/set/set.go
+++ b/set/set.go
@@ -1,12 +1,17 @@
 package set
 
-type Set[T comparable] map[T]bool
+import (
+	"cmp"
+	"slices"
+)
 
-func New[T comparable]() Set[T] {
+type Set[T cmp.Ordered] map[T]bool
+
+func New[T cmp.Ordered]() Set[T] {
 	return make(Set[T])
 }
 
-func FromSlice[T comparable](slice []T) Set[T] {
+func FromSlice[T cmp.Ordered](slice []T) Set[T] {
 	s := New[T]()
 	for _, value := range slice {
 		s[value] = true
@@ -49,5 +54,6 @@ func (s Set[T]) Slice() []T {
 	for value := range s {
 		slice = append(slice, value)
 	}
+	slices.Sort(slice)
 	return slice
 }


### PR DESCRIPTION
This pull request updates the generic `Set` implementation in `set/set.go` to require that element types are `cmp.Ordered` rather than just `comparable`. This change enables the addition of sorting functionality when converting a set to a slice. The most important changes are grouped below:

Type constraints and API changes:

* Changed the type parameter for `Set`, `New`, and `FromSlice` from `comparable` to `cmp.Ordered`, enforcing that set elements are orderable. (`set/set.go`)

Sorting enhancement:

* Modified the `Slice` method to sort the returned slice using `slices.Sort`, ensuring consistent ordering of elements. (`set/set.go`)